### PR TITLE
Bump urllib3 from 1.26.4 to 1.26.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ six==1.15.0
     # via cloudipsp
 sqlalchemy==1.4.12
     # via -r .\requirements.txt
-urllib3==1.26.4
+urllib3==1.26.5
     # via requests
 werkzeug==1.0.1
     # via


### PR DESCRIPTION
Fix CVE-2021-33503 in Urlib3<1.26.5